### PR TITLE
Don't create apps on each run

### DIFF
--- a/potd_bot.rb
+++ b/potd_bot.rb
@@ -16,7 +16,6 @@ client = Mastodon::REST::Client.new(
   base_url: ENV["MASTODON_INSTANCE"],
   bearer_token: ENV["MASTODON_TOKEN"]
 )
-client.create_app(ENV["MASTODON_APP_NAME"], ENV["MASTODON_APP_SITE"])
 
 # Choose a random Pokémon from the Pokédex
 pokemon_id = rand(807) + 1


### PR DESCRIPTION
potd bot was registering a new app with the server each time it was run. this is entirely unnecessary, an access token (which is already attached to an app) is all it needs